### PR TITLE
Merge all commits to master

### DIFF
--- a/CrystalKeeper/Core/GlobalStrings.Designer.cs
+++ b/CrystalKeeper/Core/GlobalStrings.Designer.cs
@@ -1638,7 +1638,7 @@ namespace CrystalKeeper.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to --- Version 1.1 ---.
+        ///   Looks up a localized string similar to Version 1.1.
         /// </summary>
         public static string TipAboutVersion {
             get {

--- a/CrystalKeeper/Core/GlobalStrings.resx
+++ b/CrystalKeeper/Core/GlobalStrings.resx
@@ -603,7 +603,7 @@ The collections using this template are: </value>
     <value>Crystal Keeper was developed as a free program for mineral collectors and hobbyists to store their mineral information in a convenient database with a neat and modern display.</value>
   </data>
   <data name="TipAboutVersion" xml:space="preserve">
-    <value>--- Version 1.1 ---</value>
+    <value>Version 1.1</value>
   </data>
   <data name="TipBrokenImage" xml:space="preserve">
     <value>Image link wasn't found -- click to locate or reset image.</value>

--- a/CrystalKeeper/Core/Utils.cs
+++ b/CrystalKeeper/Core/Utils.cs
@@ -94,7 +94,7 @@ namespace CrystalKeeper.Core
         }
 
         /// <summary>
-        /// Returns a unique url in the images folder using the given filename.
+        /// Returns the images folder using the given path.
         /// </summary>
         /// <param name="path">
         /// The path used as the base location for the images folder.

--- a/CrystalKeeper/Core/Utils.cs
+++ b/CrystalKeeper/Core/Utils.cs
@@ -72,7 +72,6 @@ namespace CrystalKeeper.Core
                 //Removes the root and appends it to the appdata folder.
                 string newUrlExt = Path.GetExtension(path);
 
-
                 //Creates the directories if they don't exist.
                 Directory.CreateDirectory(dir);
 
@@ -92,6 +91,28 @@ namespace CrystalKeeper.Core
                 Log("Bad url with GetAppdataFolder(): " + e.StackTrace);
                 return dir;
             }
+        }
+
+        /// <summary>
+        /// Returns a unique url in the images folder using the given filename.
+        /// </summary>
+        /// <param name="path">
+        /// The path used as the base location for the images folder.
+        /// </param>
+        public static string GetImagesFolder(string path)
+        {
+            string dir = Path.Combine(path, "ImageData");
+
+            try
+            {
+                Directory.CreateDirectory(dir);
+            }
+            catch (ArgumentException e)
+            {
+                Log("Bad url with GetImagesFolder(): " + e.StackTrace);
+            }
+
+            return dir;
         }
 
         /// <summary>

--- a/CrystalKeeper/Gui/DlgAboutGui.xaml
+++ b/CrystalKeeper/Gui/DlgAboutGui.xaml
@@ -23,7 +23,7 @@
                    FontStyle="Italic"
                    HorizontalAlignment="Center"
                    Padding="4px, 0px, 4px, 4px"
-                   Text="{x:Static local:GlobalStrings.TipAboutVersion}"/>
+                   Text="{Binding Source={x:Static local:GlobalStrings.TipAboutVersion}, StringFormat=--- {0} ---}"/>
         <TextBlock Grid.Row="2"
                    HorizontalAlignment="Center"
                    Padding="4px"

--- a/CrystalKeeper/Gui/DlgAboutGui.xaml.cs
+++ b/CrystalKeeper/Gui/DlgAboutGui.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows;
+﻿using System.Diagnostics;
+using System.Reflection;
+using System.Windows;
 
 namespace CrystalKeeper.Gui
 {
@@ -10,6 +12,16 @@ namespace CrystalKeeper.Gui
         public DlgAboutGui()
         {
             InitializeComponent();
+        }
+
+        /// <summary>
+        /// Returns the version number of the application.
+        /// </summary>
+        private string GetVersion()
+        {
+            return FileVersionInfo.GetVersionInfo
+                (Assembly.GetExecutingAssembly().Location)
+                .ProductVersion;
         }
     }
 }

--- a/CrystalKeeper/Gui/MainDisplay.cs
+++ b/CrystalKeeper/Gui/MainDisplay.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Timers;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -335,7 +336,10 @@ namespace CrystalKeeper.Gui
                 PromptEditTemplates(sender);
             }
 
-            e.Handled = true;
+            if (e != null)
+            {
+                e.Handled = true;
+            }
         }
 
         /// <summary>
@@ -1514,8 +1518,7 @@ namespace CrystalKeeper.Gui
                             //Gets the type of data to search.
                             object fieldData = field.GetData("data");
                             var templateType = (TemplateFieldType)(int)treeviewFilterField.GetData("dataType");
-                            if (templateType == TemplateFieldType.Text ||
-                                templateType == TemplateFieldType.Min_Formula ||
+                            if (templateType == TemplateFieldType.Min_Formula ||
                                 templateType == TemplateFieldType.Min_Name ||
                                 templateType == TemplateFieldType.Min_Group ||
                                 templateType == TemplateFieldType.Min_Locality ||
@@ -1523,6 +1526,26 @@ namespace CrystalKeeper.Gui
                             {
                                 if (((string)fieldData).ToLower()
                                     .Contains(treeviewFilterText.ToLower()))
+                                {
+                                    grp.Items.Add(entryRef);
+                                }
+                            }
+                            else if (templateType == TemplateFieldType.Text)
+                            {
+                                //Loads data to a rich text editor.
+                                RichTextEditor rtb = new RichTextEditor();
+                                if (fieldData is byte[])
+                                {
+                                    rtb.LoadData((byte[])fieldData);
+                                }
+
+                                //Gets the data.
+                                TextRange tr = new TextRange(
+                                    rtb.Gui.Textbox.Document.ContentStart,
+                                    rtb.Gui.Textbox.Document.ContentEnd);
+
+                                //Compares it.
+                                if (tr.Text.ToLower().Contains(treeviewFilterText.ToLower()))
                                 {
                                     grp.Items.Add(entryRef);
                                 }

--- a/CrystalKeeper/Gui/SearchboxGui.xaml
+++ b/CrystalKeeper/Gui/SearchboxGui.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:CrystalKeeper.Gui"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <StackPanel>
+    <StackPanel Name="container">
         <TextBox Name="textbox"/>
         <ListBox Name="suggestions" Visibility="Collapsed"/>
     </StackPanel>

--- a/CrystalKeeper/Properties/AssemblyInfo.cs
+++ b/CrystalKeeper/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/CrystalKeeper/Resources/Minerals.txt
+++ b/CrystalKeeper/Resources/Minerals.txt
@@ -4807,7 +4807,7 @@ Halbopal||||0
 Håleniusite-(La)|Fluorite group|LaOF|Sweden|1
 Half-Bornite||||0
 Halfbreed||||0
-Halite|Rocksalt group|NaCl|unknown|1
+Halite|Halite group|NaCl|unknown|1
 Halitosylvin||||0
 Hallerite||||0
 Hallimondite||Pb_2_(UO_2_)(AsO_4_)_2_·nH_2_O|Germany|1


### PR DESCRIPTION
e4cce93: The searchbox now closes when focus is moved away from it in all scenarios. It displays only 10 suggestions at a time and stops iterating through them once 10 have been found. Suggestions starting with what the user types is displayed first, followed by suggestions containing the user's text, up to a max of 10 elements.

ae70cc7: e.Handled was being set to true when e was null via call to GuiTemplateNew_Click() from trying to create a collection with no templates.

feedb9f: Packing binary assets required copying them to temporary files every time the file was loaded, which is a naiive approach that leads to long loading times. Changed to storing assets in an "ImageData" folder, which must be in the same parent directory as the database. Having a file format that allows easy access or streaming of segments, e.g. an actual database is probably the best path.

8299304: Refactored load/save in Project.cs a little just to extract functions for getting the image folder or copying to it.

c97d5bd: Correction to minerals database, changed how version number is displayed.